### PR TITLE
add record tag (prototype) and fix commify for floats

### DIFF
--- a/actionkit_templates/settings.py
+++ b/actionkit_templates/settings.py
@@ -76,7 +76,12 @@ def _get_context_data(request, name, page, use_referer=False):
         port = hostport[1]
 
     if use_referer:
-        paths = urlparse.urlparse(request.META['HTTP_REFERER']).path.split('/')
+        paths = None
+        if request.META.get('HTTP_REFERER'):
+            paths = urlparse.urlparse(request.META['HTTP_REFERER']).path.split('/')
+        elif request.GET.get('path'):
+            # e.g. &path=/events/event_search.html
+            paths = request.GET['path'].split('/')
         if paths and len(paths) > 1:
             name = paths[1]
             if len(paths) > 2:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Schuyler Duveen',
     author_email='opensource@moveon.org',
     packages=find_packages(),
-    package_data={'actionkit_templates': ['templates/*.html']},
+    package_data={'actionkit_templates': ['templates/*.html', 'contexts/*.csv']},
     url='https://github.com/MoveOnOrg/actionkit-templates',
     license='MIT',
     description="actionkit-templates allows you to view your ActionKit templates locally testing different configurations for each page type.  It also documents by-code many context variables for each page",


### PR DESCRIPTION
I attended ClientCon last week, and presented on this repo, actionkit-templates.  That is why I was working on this -- to fix some bugs discovered in the course of preparing for the presentation.

Additionally, Ethan Jucovy presented on a very useful template tag, that I believe the MoveOn team could use in similar ways also documented here:
https://thirdbearsolutions.com/blog/hosting-quizzes-actionkit/

and also in the PR as a way to use it:
https://github.com/MoveOnOrg/actionkit-templates/pull/16/files#diff-71a308e5e80334c7f6dec2d835b07ac0R87

Before we can use the record tag we should have it in this repo, so that we can test where it's used in templates.  

Also this fixes commify filter for floats, an issue that came up while developing the presentation -- it can be used for decimal values for donations, and seems to work in ActionKit.

@ejucovy Maybe you could test my prototype of the `record` tag with some of your templates, for edge case-differences.