### PR TITLE
support python3 (but still allow python2)

### DIFF
--- a/actionkit_templates/settings.py
+++ b/actionkit_templates/settings.py
@@ -2,7 +2,11 @@ import json
 import os
 import sys
 import time
-import urlparse
+try:
+    from urlparse import urlparse
+except ImportError:
+    # python3
+    from urllib.parse import urlparse
 
 from django.conf.urls import url
 from django.conf.urls.static import static
@@ -78,7 +82,7 @@ def _get_context_data(request, name, page, use_referer=False):
     if use_referer:
         paths = None
         if request.META.get('HTTP_REFERER'):
-            paths = urlparse.urlparse(request.META['HTTP_REFERER']).path.split('/')
+            paths = urlparse(request.META['HTTP_REFERER']).path.split('/')
         elif request.GET.get('path'):
             # e.g. &path=/events/event_search.html
             paths = request.GET['path'].split('/')

--- a/actionkit_templates/templatetags/switchcase.py
+++ b/actionkit_templates/templatetags/switchcase.py
@@ -64,7 +64,7 @@ def do_switch(parser, token):
         token_name, token_args = contents[0], contents[1:]
 
         if token_name == 'case':
-            tests = map(parser.compile_filter, token_args)
+            tests = list(map(parser.compile_filter, token_args))
             case = (tests, nodelist)
             got_case = True
         else:


### PR DESCRIPTION
This allows python3 to be used, but also supports backwards compatibility with python2.

ActionKit (finally) upgraded to python3 so now we can support that environment.