### PR TITLE
Pass in arg params for donate.16 context

### DIFF
--- a/actionkit_templates/contexts/donation_contexts.py
+++ b/actionkit_templates/contexts/donation_contexts.py
@@ -42,6 +42,7 @@ args_permutations = {
     "donation_type": ["recurring", "single"],
     "payment_hash": ["abc123"],
     "suggested_ask": ["20", "666"],
+    "weekly": ["1"]
 }
 
 def user(recurring=1, payment_hash=False, customfields=None, previous_recurring=False, id=666):
@@ -239,7 +240,7 @@ contexts = {
     'donate.13': compose([base('two candidates quickpay', entity='pac', layout='donate_5050_split'), user(0, payment_hash=True), candidates2], ["payment_hash"], -1),
     'donate.14': compose([base('1 product'), products]),
     'donate.15': compose([base('2 products'), products2]),
-    'donate.16': compose([base('weekly recurring checkbox', layout="make_weekly_checkbox")]),
+    'donate.16': compose([base('weekly recurring checkbox', layout="make_weekly_checkbox")], ["donation_type", "weekly"]),
     'donate.17': compose([base('quickpay recurring checkbox', entity='pac', layout="donate_5050_split"), user(0, payment_hash=True), candidates], ["payment_hash"], -1),
     'donate.18': compose([base('quickpay', entity='pac', layout='donate_5050_split donation_no_checkbox'), user(0, payment_hash=True), candidates], ["payment_hash"], -1),
     'donate.19': compose([base('quickpay with weekly', entity='pac', layout="make_weekly_checkbox"), user(0, payment_hash=True), candidates], ["payment_hash"], -1),


### PR DESCRIPTION
Pass `donation_type = "recurring"` and `weekly = "1"` params into donate.16 to fix failing Travis CI tests