### PR TITLE
added account to recurring paypal profile

### DIFF
--- a/actionkit_templates/contexts/account_contexts.py
+++ b/actionkit_templates/contexts/account_contexts.py
@@ -243,6 +243,7 @@ contexts = {
         "show_paypal": True,
         "paypal_cohort": 0,
         'active': [{  # profile
+            'account': 'MoveOnPAC PayPal',
             'id': '123',
             'payment_processor_information': {
                 'use_cse': False,


### PR DESCRIPTION
Adding account name to the recurring paypal data bc that is how the new recurring_updates page is determining whether to show paypal-relevant info.